### PR TITLE
Upgrade Influent to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,4 @@ $ echo '{"messmages": "Hi, Kafka connect!"}' | fluent-cat connect-test --time-as
 **NOTE:**
 
 Specify tag same as topics in FluentdSourceConnector.properties and FluentdSinkConnector.properties.
-Use Fluentd v0.12.x because influent does not support nanoseconds yet.
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,5 @@ dependencies {
        Please review and delete this closure when resolved. */
     }
     compile group: "org.komamitsu", name: "fluency", version: "1.4.0"
-    compile group: "com.okumin", name: "influent-java", version: "0.2.0"
+    compile group: "com.okumin", name: "influent-java", version: "0.3.0"
 }

--- a/src/main/java/org/fluentd/kafka/FluentdSourceConnectorConfig.java
+++ b/src/main/java/org/fluentd/kafka/FluentdSourceConnectorConfig.java
@@ -37,8 +37,8 @@ public class FluentdSourceConnectorConfig extends AbstractConfig {
      */
     public static final String FLUENTD_PORT = "fluentd.port";
     public static final String FLUENTD_BIND = "fluentd.bind";
-    // public static final String FLUENTD_CHUNK_SIZE_LIMIT = "fluentd.chunk.size.limit";
-    // public static final String FLUENTD_WORKER_POOL_SIZE = "fluentd.worker.pool.size";
+    public static final String FLUENTD_CHUNK_SIZE_LIMIT = "fluentd.chunk.size.limit";
+    public static final String FLUENTD_WORKER_POOL_SIZE = "fluentd.worker.pool.size";
 
     public FluentdSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -53,7 +53,11 @@ public class FluentdSourceConnectorConfig extends AbstractConfig {
                 .define(FLUENTD_PORT, Type.INT, 24224, Importance.HIGH,
                         "Port number to listen. Default: 24224")
                 .define(FLUENTD_BIND, Type.STRING, "0.0.0.0", Importance.HIGH,
-                        "Bind address to listen. Default: 0.0.0.0");
+                        "Bind address to listen. Default: 0.0.0.0")
+                .define(FLUENTD_CHUNK_SIZE_LIMIT, Type.LONG, Long.MAX_VALUE, Importance.MEDIUM,
+                        "The size limit of the the received chunk. Default: Long.MAX_VALUE")
+                .define(FLUENTD_WORKER_POOL_SIZE, Type.INT, 1, Importance.MEDIUM,
+                        "The worker parallelism. Default: 1");
     }
 
     public int getFluentdPort() {
@@ -62,6 +66,14 @@ public class FluentdSourceConnectorConfig extends AbstractConfig {
 
     public String getFluentdBind() {
         return this.getString(FLUENTD_BIND);
+    }
+
+    public long getFluentdChunkSizeLimit() {
+        return this.getLong(FLUENTD_CHUNK_SIZE_LIMIT);
+    }
+
+    public int getFluentdWorkerPoolSize() {
+        return this.getInt(FLUENTD_WORKER_POOL_SIZE);
     }
 
     public SocketAddress getLocalAddress() throws FluentdConnectorConfigError {

--- a/src/main/java/org/fluentd/kafka/FluentdSourceTask.java
+++ b/src/main/java/org/fluentd/kafka/FluentdSourceTask.java
@@ -45,6 +45,7 @@ public class FluentdSourceTask extends SourceTask {
                 );
                 queue.add(sourceRecord);
             });
+            // TODO complete this future when SourceTask#commit finishes
             return CompletableFuture.completedFuture(null);
         });
         // TODO configure server
@@ -52,6 +53,8 @@ public class FluentdSourceTask extends SourceTask {
             server = new ForwardServer
                     .Builder(callback)
                     .localAddress(config.getLocalAddress())
+                    .chunkSizeLimit(config.getFluentdChunkSizeLimit())
+                    .workerPoolSize(config.getFluentdWorkerPoolSize())
                     .build();
         } catch (FluentdConnectorConfigError ex) {
             throw new ConnectException(ex);


### PR DESCRIPTION
I released Influent 0.3.0, so upgrade the dependency version.
https://github.com/okumin/influent/releases/tag/v0.3.0

## Point to review

* Importance of FLUENTD_CHUNK_SIZE_LIMIT and FLUENTD_WORKER_POOL_SIZE
* The default value of worker pool size
    * Should use the num of availableProcessers?