### PR TITLE
Support schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ See also [kafka-connect benchmark scripts](https://github.com/fluent/fluentd-ben
   * Password for key
 * kafka.topic
   * Topic for Kafka. `null` means using Fluentd's tag for topic dynamically. Default: `null`
+* fluentd.schemas.enable
+  * Enable schemas for messages. Default: `true`
 * fluentd.counter.enabled
   * **For developer only** Enable counter for messages/sec. Default: `false`
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,12 @@ repositories {
      maven { url "https://repo.maven.apache.org/maven2" }
 }
 dependencies {
-    testCompile group: "junit", name: "junit", version:"4.12"
+    testCompile group: "junit", name: "junit", version:"4.+"
     testCompile group: "org.hamcrest", name: "hamcrest-all", version:"1.3"
     testCompile group: "org.powermock", name: "powermock-module-junit4", version: "1.7.1"
     testCompile group: "org.powermock", name: "powermock-api-easymock", version: "1.7.1"
     testCompile group: "org.easymock", name: "easymock", version: "3.4"
-    compile(group: "org.apache.kafka", name: "connect-api", version:"0.11.0.0") {
+    compile(group: "org.apache.kafka", name: "connect-api", version:"1.0.0") {
        /* This dependency was originally in the Maven provided scope, but the project was not of type war.
        This behavior is not yet supported by Gradle, so this dependency has been converted to a compile dependency.
        Please review and delete this closure when resolved. */

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.fluentd.kafka"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """kafka-connect-fluentd"""
 

--- a/src/main/java/org/fluentd/kafka/FluentdSourceConnectorConfig.java
+++ b/src/main/java/org/fluentd/kafka/FluentdSourceConnectorConfig.java
@@ -48,6 +48,7 @@ public class FluentdSourceConnectorConfig extends AbstractConfig {
     public static final String FLUENTD_KEY_PASSWORD = "fluentd.key.password";
 
     public static final String KAFKA_TOPIC = "kafka.topic";
+    public static final String FLUENTD_SCHEMAS_ENABLE = "fluentd.schemas.enable";
     public static final String FLUENTD_COUNTER_ENABLED = "fluentd.counter.enabled";
 
     public FluentdSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
@@ -90,6 +91,8 @@ public class FluentdSourceConnectorConfig extends AbstractConfig {
                         "Password for key")
                 .define(KAFKA_TOPIC, Type.STRING, null, Importance.MEDIUM,
                         "Topic for Kafka. null means using Fluentd's tag for topic dynamically. Default: null")
+                .define(FLUENTD_SCHEMAS_ENABLE, Type.BOOLEAN, true, Importance.MEDIUM,
+                        "Enable schemas for messages. Default: true")
                 .define(FLUENTD_COUNTER_ENABLED, Type.BOOLEAN, false, Importance.MEDIUM,
                         "Enable counter for messages/sec. Default: false");
     }
@@ -160,6 +163,10 @@ public class FluentdSourceConnectorConfig extends AbstractConfig {
 
     public String getFluentdStaticTopic() {
         return getString(KAFKA_TOPIC);
+    }
+
+    public boolean isFluentdSchemasEnable() {
+        return getBoolean(FLUENTD_SCHEMAS_ENABLE);
     }
 
     public boolean getFluentdCounterEnabled() {

--- a/src/main/java/org/fluentd/kafka/MessagePackConverver.java
+++ b/src/main/java/org/fluentd/kafka/MessagePackConverver.java
@@ -1,0 +1,119 @@
+package org.fluentd.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import influent.EventEntry;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.msgpack.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MessagePackConverver {
+    static final Logger log = LoggerFactory.getLogger(MessagePackConverver.class);
+    private final FluentdSourceConnectorConfig config;
+
+    public MessagePackConverver(final FluentdSourceConnectorConfig config) {
+        this.config = config;
+    }
+
+    public SourceRecord convert(String topic, String tag, Long timestamp, EventEntry entry) {
+        if (config.isFluentdSchemasEnable()) {
+            SchemaAndValue schemaAndValue = convert(topic, entry);
+            return new SourceRecord(
+                    null,
+                    null,
+                    topic,
+                    null,
+                    Schema.STRING_SCHEMA,
+                    tag,
+                    schemaAndValue.schema(),
+                    schemaAndValue.value(),
+                    timestamp
+            );
+        } else {
+            Object record;
+            try {
+                record = new ObjectMapper().readValue(entry.getRecord().toJson(), LinkedHashMap.class);
+            } catch (IOException e) {
+                record = entry.getRecord().toJson();
+            }
+            return new SourceRecord(
+                    null,
+                    null,
+                    topic,
+                    null,
+                    null,
+                    null,
+                    null,
+                    record,
+                    timestamp
+            );
+        }
+    }
+
+    public SourceRecord convert(String topic, String tag, Instant timestamp, EventEntry entry) {
+        return convert(topic, tag, timestamp.toEpochMilli(), entry);
+    }
+
+    private SchemaAndValue convert(String topic, EventEntry entry) {
+        return convert(topic, entry.getRecord());
+    }
+
+    private SchemaAndValue convert(String name, Value value) {
+        switch (value.getValueType()) {
+            case STRING:
+                return new SchemaAndValue(Schema.STRING_SCHEMA, value.asStringValue().asString());
+            case NIL:
+                return new SchemaAndValue(Schema.OPTIONAL_STRING_SCHEMA, null);
+            case BOOLEAN:
+                return new SchemaAndValue(Schema.BOOLEAN_SCHEMA, value.asBooleanValue().getBoolean());
+            case INTEGER:
+                return new SchemaAndValue(Schema.INT64_SCHEMA, value.asIntegerValue().toLong());
+            case FLOAT:
+                // We cannot identify float32 and float64. We must treat float64 as double.
+                return new SchemaAndValue(Schema.FLOAT64_SCHEMA, value.asFloatValue().toDouble());
+            case BINARY:
+                return new SchemaAndValue(Schema.BYTES_SCHEMA, value.asBinaryValue().asByteArray());
+            case MAP: {
+                SchemaBuilder builder = SchemaBuilder.struct().name(name);
+                Map<Value, Value> map = value.asMapValue().map();
+                Map<String, SchemaAndValue> fields = new HashMap<>();
+                map.forEach((k, v) -> {
+                    String n = k.asStringValue().asString();
+                    fields.put(n, convert(n, v));
+                });
+                fields.forEach((k, v) -> {
+                    builder.field(k, v.schema());
+                });
+                Schema schema = builder.build();
+                Struct struct = new Struct(schema);
+                fields.forEach((k, v) -> {
+                    struct.put(k, v.value());
+                });
+                return new SchemaAndValue(schema, struct);
+            }
+            case ARRAY: {
+                List<Value> array = value.asArrayValue().list();
+                SchemaAndValue sv = convert(name, array.get(0));
+                ArrayList<Object> values = new ArrayList<>();
+                SchemaBuilder.type(sv.schema().type());
+                array.forEach(val -> values.add(convert(null, val).value()));
+                Schema schema = SchemaBuilder.array(sv.schema()).optional().build();
+                return new SchemaAndValue(schema, values);
+            }
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/org/fluentd/kafka/MessagePackConverver.java
+++ b/src/main/java/org/fluentd/kafka/MessagePackConverver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 ClearCode Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
 package org.fluentd.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/org/fluentd/kafka/MessagePackConverterTest.java
+++ b/src/test/java/org/fluentd/kafka/MessagePackConverterTest.java
@@ -1,0 +1,144 @@
+package org.fluentd.kafka;
+
+import influent.EventEntry;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Assert;
+import org.junit.Test;
+import org.msgpack.value.ValueFactory;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MessagePackConverterTest {
+    @Test
+    public void simpleKeyValue() {
+        Map<String, String> map = new HashMap<>();
+        map.put(FluentdSourceConnectorConfig.FLUENTD_SCHEMAS_ENABLE, "true");
+        FluentdSourceConnectorConfig config = new FluentdSourceConnectorConfig(map);
+        EventEntry eventEntry = EventEntry.of(
+                Instant.now(),
+                ValueFactory.newMap(
+                        ValueFactory.newString("message"),
+                        ValueFactory.newString("This is a message."),
+                        ValueFactory.newString("flag"),
+                        ValueFactory.newBoolean(true)));
+
+        MessagePackConverver converter = new MessagePackConverver(config);
+        SourceRecord sourceRecord = converter.convert("topic", "tag", 0L, eventEntry);
+
+        assertEquals(Schema.STRING_SCHEMA, sourceRecord.keySchema());
+        assertEquals("tag", sourceRecord.key());
+        assertEquals("topic", sourceRecord.valueSchema().name());
+        Struct struct = (Struct) sourceRecord.value();
+        assertEquals("This is a message.", struct.get("message"));
+        assertTrue(struct.getBoolean("flag"));
+    }
+
+    @Test
+    public void nullValue() {
+        Map<String, String> map = new HashMap<>();
+        map.put(FluentdSourceConnectorConfig.FLUENTD_SCHEMAS_ENABLE, "true");
+        FluentdSourceConnectorConfig config = new FluentdSourceConnectorConfig(map);
+        EventEntry eventEntry = EventEntry.of(
+                Instant.now(),
+                ValueFactory.newMap(
+                        ValueFactory.newString("message"),
+                        ValueFactory.newNil()));
+
+        MessagePackConverver converter = new MessagePackConverver(config);
+        SourceRecord sourceRecord = converter.convert("topic", "tag", 0L, eventEntry);
+
+        assertEquals(Schema.STRING_SCHEMA, sourceRecord.keySchema());
+        assertEquals("tag", sourceRecord.key());
+        assertEquals("topic", sourceRecord.valueSchema().name());
+        Struct struct = (Struct) sourceRecord.value();
+        assertNull(struct.get("message"));
+    }
+
+    @Test
+    public void nestedMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put(FluentdSourceConnectorConfig.FLUENTD_SCHEMAS_ENABLE, "true");
+        FluentdSourceConnectorConfig config = new FluentdSourceConnectorConfig(map);
+        EventEntry eventEntry = EventEntry.of(
+                Instant.now(),
+                ValueFactory.newMap(
+                        ValueFactory.newString("message"),
+                        ValueFactory.newString("This is a message."),
+                        ValueFactory.newString("nested"),
+                        ValueFactory.newMap(
+                                ValueFactory.newString("key"),
+                                ValueFactory.newInteger(42)
+                        )));
+
+        MessagePackConverver converter = new MessagePackConverver(config);
+        SourceRecord sourceRecord = converter.convert("topic", "tag", 0L, eventEntry);
+
+        assertEquals(Schema.STRING_SCHEMA, sourceRecord.keySchema());
+        assertEquals("tag", sourceRecord.key());
+        assertEquals("topic", sourceRecord.valueSchema().name());
+        Struct struct = (Struct) sourceRecord.value();
+        assertEquals("This is a message.", struct.get("message"));
+        Struct nested = struct.getStruct("nested");
+        Long expected = 42L;
+        assertEquals(expected, nested.getInt64("key"));
+    }
+
+    @Test
+    public void nestedArray() {
+        Map<String, String> map = new HashMap<>();
+        map.put(FluentdSourceConnectorConfig.FLUENTD_SCHEMAS_ENABLE, "true");
+        FluentdSourceConnectorConfig config = new FluentdSourceConnectorConfig(map);
+        EventEntry eventEntry = EventEntry.of(
+                Instant.now(),
+                ValueFactory.newMap(
+                        ValueFactory.newString("message"),
+                        ValueFactory.newString("This is a message."),
+                        ValueFactory.newString("nested"),
+                        ValueFactory.newArray(
+                                ValueFactory.newFloat(3.14f),
+                                ValueFactory.newFloat(42.195f)
+                        )));
+
+        MessagePackConverver converter = new MessagePackConverver(config);
+        SourceRecord sourceRecord = converter.convert("topic", "tag", 0L, eventEntry);
+
+        assertEquals(Schema.STRING_SCHEMA, sourceRecord.keySchema());
+        assertEquals("tag", sourceRecord.key());
+        assertEquals("topic", sourceRecord.valueSchema().name());
+        Struct struct = (Struct) sourceRecord.value();
+        assertEquals("This is a message.", struct.get("message"));
+        List<Double> list = struct.getArray("nested");
+        assertEquals(list.get(0), 3.14, 0.01);
+        assertEquals(list.get(1), 42.195, 0.01);
+    }
+
+    @Test
+    public void schemalessKeyValue() {
+        Map<String, String> map = new HashMap<>();
+        map.put(FluentdSourceConnectorConfig.FLUENTD_SCHEMAS_ENABLE, "false");
+        FluentdSourceConnectorConfig config = new FluentdSourceConnectorConfig(map);
+        EventEntry eventEntry = EventEntry.of(
+                Instant.now(),
+                ValueFactory.newMap(
+                        ValueFactory.newString("message"),
+                        ValueFactory.newString("This is a message.")));
+
+        MessagePackConverver converter = new MessagePackConverver(config);
+        SourceRecord sourceRecord = converter.convert("topic", "tag", 0L, eventEntry);
+
+        Assert.assertNull(sourceRecord.keySchema());
+        Assert.assertNull(sourceRecord.key());
+        Assert.assertNull(sourceRecord.valueSchema());
+        Map<String, Object> value = (Map<String, Object>) sourceRecord.value();
+        Assert.assertEquals("This is a message.", value.get("message"));
+    }
+}


### PR DESCRIPTION
We can use FluentdSource instead of fluent-plugin-kafka.
Using following configurations:

FluentdSourceConnector.properties:
```
...
fluentd.schemas.enable = false
```

connect-standalone.properties
```
key.converter.schemas.enable=false
value.converter.schemas.enable=false
```