### PR TITLE
Support multi tasks on distributed mode

### DIFF
--- a/src/main/java/org/fluentd/kafka/FluentdSinkConnector.java
+++ b/src/main/java/org/fluentd/kafka/FluentdSinkConnector.java
@@ -59,7 +59,9 @@ public class FluentdSinkConnector extends SinkConnector {
     public List<Map<String, String>> taskConfigs(int maxTasks) {
         //TODO: Define the individual task configurations that will be executed.
         List<Map<String, String>> taskConfigs = new ArrayList<>();
-        taskConfigs.add(this.properties);
+        for (int i = 0; i < maxTasks; ++i) {
+            taskConfigs.add(this.properties);
+        }
         return taskConfigs;
     }
 

--- a/src/main/java/org/fluentd/kafka/FluentdSourceConnector.java
+++ b/src/main/java/org/fluentd/kafka/FluentdSourceConnector.java
@@ -56,7 +56,9 @@ public class FluentdSourceConnector extends SourceConnector {
     public List<Map<String, String>> taskConfigs(int taskMax) {
         //TODO: Define the individual task configurations that will be executed.
         List<Map<String, String>> taskConfigs = new ArrayList<>();
-        taskConfigs.add(this.properties);
+        for (int i = 0; i < taskMax; ++i) {
+            taskConfigs.add(this.properties);
+        }
         return taskConfigs;
     }
 

--- a/src/test/java/org/fluentd/kafka/FluentdSourceConnectorTest.java
+++ b/src/test/java/org/fluentd/kafka/FluentdSourceConnectorTest.java
@@ -67,7 +67,7 @@ public class FluentdSourceConnectorTest {
         PowerMock.replayAll();
         connector.start(buildSourceProperties());
         List<Map<String, String>> taskConfigs = connector.taskConfigs(10);
-        Assert.assertEquals(1, taskConfigs.size());
+        Assert.assertEquals(10, taskConfigs.size());
         Assert.assertEquals("24225", taskConfigs.get(0).get(FluentdSourceConnectorConfig.FLUENTD_PORT));
         Assert.assertEquals("127.0.0.1", taskConfigs.get(0).get(FluentdSourceConnectorConfig.FLUENTD_BIND));
         Assert.assertEquals("100", taskConfigs.get(0).get(FluentdSourceConnectorConfig.FLUENTD_CHUNK_SIZE_LIMIT));


### PR DESCRIPTION
If more than two tasks is assigned on the same node, starting process do no operation.
Because multi influent server on the same node is almost useless.
And so, I added checking port availability before launching server.